### PR TITLE
Fix/comments with input terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+* commented out equation block before actual equation block in the input file with a very long line is now handled correctly.
+
 ## Version [v1.0.1] - 2024.02.27
 
 ### Changed

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -41,7 +41,7 @@ void Output::setvals()
   small = std::pow(10,-pout->precision());
 }
 
-void Output::flushbuf()
+void Output::flushbuf(bool linebreak)
 {
   uint offset = 60;
   std::list<char> pm = {'+', '-', '('};
@@ -50,7 +50,7 @@ void Output::flushbuf()
     ipos0 = 0;
     ipos = ipos0;
     for(char& c : buf.str()){
-      if(ipos > maxlenline+offset && InSet(c,pm)){
+      if(ipos > maxlenline+offset && InSet(c,pm) && linebreak){
         *pout <<"\\nl"<<std::endl;
         lenline=0;
         nlines+=hline;

--- a/src/globals.h
+++ b/src/globals.h
@@ -138,7 +138,7 @@ class Output
   // end equation (+flushbuf)
   void eeq(bool doflush=true);
   // flash buffer
-  void flushbuf();
+  void flushbuf(bool linebreak=true);
   // if true: this is in an equation
   bool inequation;
   // break line if to long

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
       const std::vector<std::string> & finlines = finput.inlines();
       for ( unsigned int i = 0; i < finlines.size(); ++i ){
         MyOut::pcurout->buf << finlines[i] << endl;
-        MyOut::pcurout->flushbuf();
+        MyOut::pcurout->flushbuf(false);
       }
       // write to a file
       // input-equation


### PR DESCRIPTION
An input file with a commented out equation block, which triggers a linebreak in flushbuf because of its length caused
the rest of the comment to be printed in the .tex file on a new line without a prepended comment sign.
```
prog,spinintegr=1
prog,algo=2
output,level=2

%\beq
%<\Phi^{ab}_{ij}| \op H (1 + \op T_2 + \half \op T_2 \op T_2 ) |0>_C + (-\frac{1}{4}*1  +\frac{1}{4}* \Perm{AB {BA})\sum_{KLDC} \tnsr \intg{KD}{LC} \tnsr T^{KL}_{AB} \tnsr T^{IJ}_{DC} + ( 1 - \Perm{AB}{BA} ) \sum_{KLCD} \tnsr \intg{KD}{LC}\tnsr T^{IK}_{AC}\tnsr T^{JL}_{BD} + (-0.5 + 0.5*\Perm{IJ}{JI} ) \sum_{KLDC} \tnsr \intg{KC}{LD} \tnsr T^{IK}_{DC} \tnsr T^{JL}_{AB} + (-0.5 + 0.5 * \Perm{AB}{BA}) \sum_{KLDC} \tnsr \intg{KC}{LD} \tnsr T^{KL}_{CA} \tnsr T^{IJ}_{BD}
%\eeq
\beq
<\Phi^{ab}_{ij}| \op H (1 + \op T_2 + \half \op T_2 \op T_2 ) |0>_C + (-\frac{1}{4}*1  +\frac{1}{4}* \Perm{AB}{BA})\sum_{KLDC} \tnsr \intg{KD}{LC} \tnsr T^{KL}_{AB} \tnsr T^{IJ}_{DC} + ( 1 - \Perm{AB}{BA} ) \sum_{KLCD} \tnsr \intg{KD}{LC}\tnsr T^{IK}_{AC}\tnsr T^{JL}_{BD} + (-0.5 + 0.5*\Perm{IJ}{JI} ) \sum_{KLDC} \tnsr \intg{KC}{LD} \tnsr T^{IK}_{DC} \tnsr T^{JL}_{AB} + (-0.5 + 0.5 * \Perm{AB}{BA}) \sum_{KLDC} \tnsr \intg{KC}{LD} \tnsr T^{KL}_{CA} \tnsr T^{IJ}_{BD}
\eeq
```